### PR TITLE
Updated Redux integration code example

### DIFF
--- a/source/redux.md
+++ b/source/redux.md
@@ -40,14 +40,19 @@ export class AppComponent {
       apollo: client.reducer() as any,
     });
 
+    let enhancers = [
+      applyMiddleware(client.middleware()),
+    ];
+
+    if (devTools.isEnabled()) {
+      enhancers.push(devTools.enhancer());
+    }
+
     store.configureStore(
       rootReducer,
       { /* initial state */ },
       [ /* epics */ ],
-      [
-        applyMiddleware(client.middleware()),
-        devTools.isEnabled() ? devTools.enhancer() : null
-      ]
+      enhancers
     );
   }
 }


### PR DESCRIPTION
The previous integration code caused build errors due to setting a `null` enhancer when devTools are disabled which is usually the case during production mode.