### PR TITLE
Add peer deps to npm install

### DIFF
--- a/source/initialization.md
+++ b/source/initialization.md
@@ -7,7 +7,7 @@ order: 2
 To get started with Apollo and Angular, install the `apollo-client` npm package, the `apollo-angular` integration package, and the `graphql-tag` library for constructing query documents:
 
 ```bash
-npm install apollo-client apollo-angular graphql-tag --save
+npm install apollo-client apollo-angular graphql-tag @angular/core rxjs zone.js --save
 ```
 
 If you are in an environment that does not have a global [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch) implementation, make sure to install a polyfill like [`whatwg-fetch`](https://www.npmjs.com/package/whatwg-fetch).


### PR DESCRIPTION
angular, rxjs, and zone.js are not installed automatically by npm v3 or v4