### PR TITLE
fix typo in angular-cli.md

### DIFF
--- a/source/angular-cli.md
+++ b/source/angular-cli.md
@@ -36,6 +36,6 @@ ng serve --proxy-config <path to file>
 An example:
 
 ```bash
-ng server --proxy-config proxy.config.json
+ng serve --proxy-config proxy.config.json
 ```
 


### PR DESCRIPTION
Just a small typo in the documentation.